### PR TITLE
throw error on username/password registration

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1344,6 +1344,7 @@ class RoomCreationHandler:
         )
 
         if preset_config["encrypted"] or room_encryption_event:
+            raise SynapseError(400, "You cannot create an encrypted room.")
             if self._default_power_level_content_override:
                 override = self._default_power_level_content_override.get(preset_name)
                 if override is not None:

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -468,8 +468,9 @@ class RegisterRestServlet(RestServlet):
         # the auth layer will store these in sessions.
         desired_username = None
         if "username" in body:
+            raise SynapseError(400, "Username/password registration is disabled on this server")
             desired_username = body["username"]
-            if not isinstance(desired_username, str) or len(desired_username) > 512 or True:
+            if not isinstance(desired_username, str) or len(desired_username) > 512:
                 raise SynapseError(400, "Invalid username")
 
         # fork off as soon as possible for ASes which have completely

--- a/synapse/rest/client/register.py
+++ b/synapse/rest/client/register.py
@@ -469,7 +469,7 @@ class RegisterRestServlet(RestServlet):
         desired_username = None
         if "username" in body:
             desired_username = body["username"]
-            if not isinstance(desired_username, str) or len(desired_username) > 512:
+            if not isinstance(desired_username, str) or len(desired_username) > 512 or True:
                 raise SynapseError(400, "Invalid username")
 
         # fork off as soon as possible for ASes which have completely


### PR DESCRIPTION
throw error on username/password registration

The homeserver doesn't allow registering using password but if you visit the https://im.the-revivalists.org/#/register then it still gives you the option to signup using password. And if you proceed then it lets you do that. This PR disables the password from the backend so it's not possible even from other synapse clients to signup using password